### PR TITLE
Solve: 프로그래머스 - 숫자 문자열과 영단어

### DIFF
--- a/ALGODam/ALGODam.xcodeproj/project.pbxproj
+++ b/ALGODam/ALGODam.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E7637A1729D7DA3E000C1E40 /* bj1074.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7637A1629D7DA3E000C1E40 /* bj1074.swift */; };
 		E7CC0D2029CC0E5B001EAC65 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CC0D1F29CC0E5B001EAC65 /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -25,11 +26,12 @@
 /* Begin PBXFileReference section */
 		E72FF04629CC9468003002B4 /* bj1058.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bj1058.swift; sourceTree = "<group>"; };
 		E7637A1429D719A2000C1E40 /* bj2630.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bj2630.swift; sourceTree = "<group>"; };
+		E7637A1629D7DA3E000C1E40 /* bj1074.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bj1074.swift; sourceTree = "<group>"; };
 		E7CC0D1C29CC0E5B001EAC65 /* ALGODam */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ALGODam; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7CC0D1F29CC0E5B001EAC65 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E7CC0D2929CC0FDE001EAC65 /* test1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test1.swift; sourceTree = "<group>"; };
 		E7CC0D2C29CC0FEF001EAC65 /* BJ1100.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BJ1100.swift; sourceTree = "<group>"; };
-		E7CC0D2E29CC0FFA001EAC65 /* test3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test3.swift; sourceTree = "<group>"; };
+		E7CC0D2E29CC0FFA001EAC65 /* programmers-1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "programmers-1.swift"; sourceTree = "<group>"; };
 		E7CC0D3029CC142A001EAC65 /* SwiftBasic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftBasic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -75,7 +77,7 @@
 		E7CC0D2629CC0F99001EAC65 /* Programmers */ = {
 			isa = PBXGroup;
 			children = (
-				E7CC0D2E29CC0FFA001EAC65 /* test3.swift */,
+				E7CC0D2E29CC0FFA001EAC65 /* programmers-1.swift */,
 			);
 			path = Programmers;
 			sourceTree = "<group>";
@@ -86,6 +88,7 @@
 				E72FF04629CC9468003002B4 /* bj1058.swift */,
 				E7CC0D2C29CC0FEF001EAC65 /* BJ1100.swift */,
 				E7637A1429D719A2000C1E40 /* bj2630.swift */,
+				E7637A1629D7DA3E000C1E40 /* bj1074.swift */,
 			);
 			path = Baekjoon;
 			sourceTree = "<group>";
@@ -157,6 +160,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7CC0D2029CC0E5B001EAC65 /* main.swift in Sources */,
+				E7637A1729D7DA3E000C1E40 /* bj1074.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ALGODam/ALGODam.xcodeproj/project.pbxproj
+++ b/ALGODam/ALGODam.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		E7637A1729D7DA3E000C1E40 /* bj1074.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7637A1629D7DA3E000C1E40 /* bj1074.swift */; };
 		E7CC0D2029CC0E5B001EAC65 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CC0D1F29CC0E5B001EAC65 /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -26,7 +25,6 @@
 /* Begin PBXFileReference section */
 		E72FF04629CC9468003002B4 /* bj1058.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bj1058.swift; sourceTree = "<group>"; };
 		E7637A1429D719A2000C1E40 /* bj2630.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bj2630.swift; sourceTree = "<group>"; };
-		E7637A1629D7DA3E000C1E40 /* bj1074.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bj1074.swift; sourceTree = "<group>"; };
 		E7CC0D1C29CC0E5B001EAC65 /* ALGODam */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ALGODam; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7CC0D1F29CC0E5B001EAC65 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E7CC0D2929CC0FDE001EAC65 /* test1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test1.swift; sourceTree = "<group>"; };
@@ -88,7 +86,6 @@
 				E72FF04629CC9468003002B4 /* bj1058.swift */,
 				E7CC0D2C29CC0FEF001EAC65 /* BJ1100.swift */,
 				E7637A1429D719A2000C1E40 /* bj2630.swift */,
-				E7637A1629D7DA3E000C1E40 /* bj1074.swift */,
 			);
 			path = Baekjoon;
 			sourceTree = "<group>";
@@ -160,7 +157,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7CC0D2029CC0E5B001EAC65 /* main.swift in Sources */,
-				E7637A1729D7DA3E000C1E40 /* bj1074.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ALGODam/ALGODam/Programmers/programmers-1.swift
+++ b/ALGODam/ALGODam/Programmers/programmers-1.swift
@@ -1,0 +1,63 @@
+//
+//  test3.swift
+//  ALGODam
+//
+//  Created by 김담인 on 2023/03/23.
+//
+
+// MARK: - 숫자 문자열과 영단어
+import Foundation
+
+func solution(_ s:String) -> Int {
+    var arr: [Character] = s.map { $0 }
+    var sol: [String] = []
+    var i = 0
+    while i < arr.count {
+        switch arr[i] {
+            case "z":
+                i += 4
+                sol.append("0")
+            case "o":
+                i += 3
+                sol.append("1")
+            case "t":
+                if arr[i+1] == "w" {
+                    i += 3
+                    sol.append("2")
+                } else {
+                    i += 5
+                    sol.append("3")
+                }
+            case "f":
+                if arr[i+1] == "o" {
+                    i += 4
+                    sol.append("4")
+                } else {
+                    i += 4
+                    sol.append("5")
+                }
+            case "s":
+                if arr[i+1] == "i" {
+                    i += 3
+                    sol.append("6")
+                } else {
+                    i += 5
+                    sol.append("7")
+                }
+            case "e":
+                i += 5
+                sol.append("8")
+            case "n":
+                i += 4
+                sol.append("9")
+            default:
+                sol.append("\(arr[i])")
+                i += 1
+
+        }
+        
+    }
+
+    return Int(sol.reduce("",+))!
+}
+

--- a/ALGODam/ALGODam/Programmers/test3.swift
+++ b/ALGODam/ALGODam/Programmers/test3.swift
@@ -1,8 +1,0 @@
-//
-//  test3.swift
-//  ALGODam
-//
-//  Created by 김담인 on 2023/03/23.
-//
-
-import Foundation


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 문제번호 : [Programmers] 숫자 문자열과 영단어

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 각 숫자 영단어 문자의 첫글자에 따라 분기 처리 ( 같은 문자는 if 문을 추가)해서 문자열 크기만큼 인덱스 건너뛰고 다음 단어 혹은 숫자를 찾을 수 있도록 함
- 문자열을 다루는 문제라 문자열 리턴해줘야 되는 숫자도 문자로 변환을 해서 1차원 배열로 만들고 reduce로 문자열들을 더해 하나의 문자열로 변환하고 Int로 변환해서 리턴

- 다른 풀이를 보니 replacingOccurrences라는 특정 문자를 대체하는 함수가 있는 걸 알아서 이 함수를 이용해 훨씬 간단하게 풀 수 있었구나 알게되었습니다!

## ⏱️시간복잡도 O(N)
주어진 문자열의 크기 만큼 while문 반복
